### PR TITLE
50436-Unnecessary-DISABLE_WP_CRON

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -987,12 +987,6 @@ function wp_get_auto_update_message() {
 		return __( 'There may be a problem with WP-Cron. Automatic update not scheduled.' );
 	}
 
-	// See if cron is disabled
-	$cron_disabled = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
-	if ( $cron_disabled ) {
-		return __( 'WP-Cron is disabled. Automatic updates not available.' );
-	}
-
 	$time_to_next_update = human_time_diff( intval( $next_update_time ) );
 
 	// See if cron is overdue.


### PR DESCRIPTION
Unnecessary DISABLE_WP_CRON check in plugin and theme auto updates

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/50436
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
